### PR TITLE
FIX CHANNEL_FORWARDING / MultiShot

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -42,8 +42,8 @@ typedef enum {
     FEATURE_DISPLAY = 1 << 17,
     FEATURE_ONESHOT125 = 1 << 18,
     FEATURE_BLACKBOX = 1 << 19,
-	FEATURE_MULTISHOT = 1 << 20,
-	FEATURE_CHANNEL_FORWARDING = 1 << 21,
+	FEATURE_CHANNEL_FORWARDING = 1 << 20,
+	FEATURE_MULTISHOT = 1 << 21,
 } features_e;
 
 void handleOneshotFeatureChangeOnRestart(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -170,7 +170,7 @@ static const char * const featureNames[] = {
     "SERVO_TILT", "SOFTSERIAL", "GPS", "FAILSAFE",
     "SONAR", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "ONESHOT125",
-    "BLACKBOX", "MULTISHOT", NULL
+    "BLACKBOX", "CHANNEL_FORWARDING", "MULTISHOT", NULL
 };
 
 // sync this with rxFailsafeChannelMode_e

--- a/src/main/target/VRCORE/target.h
+++ b/src/main/target/VRCORE/target.h
@@ -72,12 +72,14 @@
 #define LED0
 #define LED1
 
+/*
 #define M25P16_CS_GPIO        GPIOB
 #define M25P16_CS_PIN         GPIO_Pin_3
 #define M25P16_SPI_INSTANCE   SPI3
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+*/
 
 #define USABLE_TIMER_CHANNEL_COUNT 12
 
@@ -115,10 +117,12 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
-#define USE_SPI_DEVICE_3
+//#define USE_SPI_DEVICE_3
 
+/*
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)
+*/
 
 #define USE_ADC
 


### PR DESCRIPTION
When It is enabled multishot, in the GUI show "CHANNEL_FORWARDING" enabled!

After this update, it is better to toggle "CHANNEL_FORWARDING", and enable again "feature multishot"
