### PR TITLE
SPI driver cleanup

### DIFF
--- a/src/main/target/ALIENFLIGHTF4/target.h
+++ b/src/main/target/ALIENFLIGHTF4/target.h
@@ -123,8 +123,25 @@
 //#define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
 
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1
+
 #define USE_SPI_DEVICE_2
+#define SPI2_NSS_GPIO           GPIOB
+#define SPI2_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI2_NSS_PIN            GPIO_Pin_12
+#define SPI2_NSS_PIN_SOURCE     GPIO_PinSource12
+#define SPI2_SCK_GPIO           GPIOB
+#define SPI2_SCK_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI2_SCK_PIN            GPIO_Pin_13
+#define SPI2_SCK_PIN_SOURCE     GPIO_PinSource13
+#define SPI2_GPIO               GPIOC
+#define SPI2_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOC
+#define SPI2_MISO_PIN           GPIO_Pin_2
+#define SPI2_MISO_PIN_SOURCE    GPIO_PinSource2
+#define SPI2_MOSI_PIN           GPIO_Pin_3
+#define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource3
+
 #define USE_SPI_DEVICE_3
 
 //#define USE_I2C

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -110,8 +110,34 @@
 #define ESCSERIAL_TIMER_TX_HARDWARE 0
 
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1
+#define SPI1_NSS_GPIO           GPIOC
+#define SPI1_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOC
+#define SPI1_NSS_PIN            GPIO_Pin_4
+#define SPI1_NSS_PIN_SOURCE     GPIO_PinSource4
+#define SPI1_GPIO               GPIOA
+#define SPI1_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOA
+#define SPI1_SCK_PIN            GPIO_Pin_5
+#define SPI1_SCK_PIN_SOURCE     GPIO_PinSource5
+#define SPI1_MISO_PIN           GPIO_Pin_6
+#define SPI1_MISO_PIN_SOURCE    GPIO_PinSource6
+#define SPI1_MOSI_PIN           GPIO_Pin_7
+#define SPI1_MOSI_PIN_SOURCE    GPIO_PinSource7
+
 #define USE_SPI_DEVICE_3
+#define SPI3_NSS_GPIO           GPIOB
+#define SPI3_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI3_NSS_PIN            GPIO_Pin_3
+#define SPI3_NSS_PIN_SOURCE     GPIO_PinSource3
+#define SPI3_GPIO               GPIOC
+#define SPI3_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOC
+#define SPI3_SCK_PIN            GPIO_Pin_10
+#define SPI3_SCK_PIN_SOURCE     GPIO_PinSource10
+#define SPI3_MISO_PIN           GPIO_Pin_11
+#define SPI3_MISO_PIN_SOURCE    GPIO_PinSource11
+#define SPI3_MOSI_PIN           GPIO_Pin_12
+#define SPI3_MOSI_PIN_SOURCE    GPIO_PinSource12
 
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -110,8 +110,22 @@
 #define S1W_RX_PIN          GPIO_Pin_11
 
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1
+
 #define USE_SPI_DEVICE_3
+#define SPI3_NSS_GPIO           GPIOB
+#define SPI3_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI3_NSS_PIN            GPIO_Pin_3
+#define SPI3_NSS_PIN_SOURCE     GPIO_PinSource3
+#define SPI3_GPIO               GPIOC
+#define SPI3_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOC
+#define SPI3_SCK_PIN            GPIO_Pin_10
+#define SPI3_SCK_PIN_SOURCE     GPIO_PinSource10
+#define SPI3_MISO_PIN           GPIO_Pin_11
+#define SPI3_MISO_PIN_SOURCE    GPIO_PinSource11
+#define SPI3_MOSI_PIN           GPIO_Pin_12
+#define SPI3_MOSI_PIN_SOURCE    GPIO_PinSource12
 
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)

--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -119,8 +119,34 @@
 #define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
 
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1 //MPU9250
+#define SPI1_NSS_GPIO           GPIOC
+#define SPI1_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOC
+#define SPI1_NSS_PIN            GPIO_Pin_4
+#define SPI1_NSS_PIN_SOURCE     GPIO_PinSource4
+#define SPI1_GPIO               GPIOA
+#define SPI1_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOA
+#define SPI1_SCK_PIN            GPIO_Pin_5
+#define SPI1_SCK_PIN_SOURCE     GPIO_PinSource5
+#define SPI1_MISO_PIN           GPIO_Pin_6
+#define SPI1_MISO_PIN_SOURCE    GPIO_PinSource6
+#define SPI1_MOSI_PIN           GPIO_Pin_7
+#define SPI1_MOSI_PIN_SOURCE    GPIO_PinSource7
+
 #define USE_SPI_DEVICE_3 //dataflash
+#define SPI3_NSS_GPIO           GPIOB
+#define SPI3_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI3_NSS_PIN            GPIO_Pin_3
+#define SPI3_NSS_PIN_SOURCE     GPIO_PinSource3
+#define SPI3_GPIO               GPIOC
+#define SPI3_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOC
+#define SPI3_SCK_PIN            GPIO_Pin_10
+#define SPI3_SCK_PIN_SOURCE     GPIO_PinSource10
+#define SPI3_MISO_PIN           GPIO_Pin_11
+#define SPI3_MISO_PIN_SOURCE    GPIO_PinSource11
+#define SPI3_MOSI_PIN           GPIO_Pin_12
+#define SPI3_MOSI_PIN_SOURCE    GPIO_PinSource12
 
 #define USE_FLASH_TOOLS
 

--- a/src/main/target/VRCORE/target.h
+++ b/src/main/target/VRCORE/target.h
@@ -122,8 +122,25 @@
 #define S1W_RX_PIN          GPIO_Pin_7
 
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1
+
 #define USE_SPI_DEVICE_2
+#define SPI2_NSS_GPIO           GPIOE
+#define SPI2_NSS_PERIPHERAL     RCC_AHBPeriph_GPIOE
+#define SPI2_NSS_PIN            GPIO_Pin_10
+#define SPI2_NSS_PIN_SOURCE     GPIO_PinSource10
+#define SPI2_SCK_GPIO           GPIOB
+#define SPI2_SCK_PERIPHERAL     RCC_AHBPeriph_GPIOB
+#define SPI2_SCK_PIN            GPIO_Pin_13
+#define SPI2_SCK_PIN_SOURCE     GPIO_PinSource13
+#define SPI2_GPIO               GPIOB
+#define SPI2_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOB
+#define SPI2_MISO_PIN           GPIO_Pin_14
+#define SPI2_MISO_PIN_SOURCE    GPIO_PinSource14
+#define SPI2_MOSI_PIN           GPIO_Pin_15
+#define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
+
 //#define USE_SPI_DEVICE_3
 
 /*


### PR DESCRIPTION
Moved all target specific code to the related target.h file. The SPI driver does not contain any target specific code anymore. It is tested for the SPI1 and SPI2 port on the ALIENFLIGHTF4 dev system. Need to be finally tested for the other targets. I plan to go ahead with this kind of updates to come to a more clean maintainable code. This will also make porting to CleanFlight and BetaFlight more easy in the future. Compiles for all F4 targets and the AW F1 and F3 without issues.
