### PR TITLE
iterm shrink causes drift on RF. Removing it unless arimode is active…

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -212,7 +212,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
             errorGyroIf[axis] *= airModePlusAxisState[axis].iTermScaler;
         }
 
-        if (allowITermShrinkOnly || motorLimitReached) {
+        if ( (IS_RC_MODE_ACTIVE(BOXAIRMODE)) && (allowITermShrinkOnly || motorLimitReached) ) { //only in airmode do we affect Ki.
             if (ABS(errorGyroIf[axis]) < ABS(previousErrorGyroIf[axis])) {
                 previousErrorGyroIf[axis] = errorGyroIf[axis];
             } else {

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -510,7 +510,7 @@ void processRx(void)
         }
 
         // Conditions to reset Error
-        if (!ARMING_FLAG(ARMED) || feature(FEATURE_MOTOR_STOP) || ((IS_RC_MODE_ACTIVE(BOXAIRMODE)) && airModeErrorResetIsEnabled) || !IS_RC_MODE_ACTIVE(BOXAIRMODE)) {
+        if (!ARMING_FLAG(ARMED) || feature(FEATURE_MOTOR_STOP) || ((IS_RC_MODE_ACTIVE(BOXAIRMODE)) && airModeErrorResetIsEnabled) || !IS_RC_MODE_ACTIVE(BOXAIRMODE) || !IS_RC_MODE_ACTIVE(BOXALWAYSSTABILIZED) ) {
             ResetErrorActivated = true;                                         // As RX code is not executed each loop a flag has to be set for fast looptimes
             airModeErrorResetTimeout = millis() + ERROR_RESET_DEACTIVATE_DELAY; // Reset de-activate timer
             airModeErrorResetIsEnabled = true;                                  // Enable Reset again especially after Disarm


### PR DESCRIPTION
…. always stabilized when at idle now
