### PR TITLE
USB: F1/F3: Send custom USB descriptor strings

### DIFF
--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -53,7 +53,6 @@ extern __IO uint32_t receiveLength;                          // HJI
 
 uint8_t receiveBuffer[64];                                   // HJI
 uint32_t sendLength;                                          // HJI
-static void IntToUnicode(uint32_t value, uint8_t *pbuf, uint8_t len);
 /* Extern variables ----------------------------------------------------------*/
 
 /* Private function prototypes -----------------------------------------------*/
@@ -226,53 +225,6 @@ void USB_Interrupts_Config(void)
 void USB_Cable_Config(FunctionalState NewState)
 {
     UNUSED(NewState);
-}
-
-/*******************************************************************************
- * Function Name  : Get_SerialNum.
- * Description    : Create the serial number string descriptor.
- * Input          : None.
- * Output         : None.
- * Return         : None.
- *******************************************************************************/
-void Get_SerialNum(void)
-{
-    uint32_t Device_Serial0, Device_Serial1, Device_Serial2;
-
-    Device_Serial0 = *(uint32_t*)ID1;
-    Device_Serial1 = *(uint32_t*)ID2;
-    Device_Serial2 = *(uint32_t*)ID3;
-
-    Device_Serial0 += Device_Serial2;
-
-    if (Device_Serial0 != 0) {
-        IntToUnicode(Device_Serial0, &Virtual_Com_Port_StringSerial[2], 8);
-        IntToUnicode(Device_Serial1, &Virtual_Com_Port_StringSerial[18], 4);
-    }
-}
-
-/*******************************************************************************
- * Function Name  : HexToChar.
- * Description    : Convert Hex 32Bits value into char.
- * Input          : None.
- * Output         : None.
- * Return         : None.
- *******************************************************************************/
-static void IntToUnicode(uint32_t value, uint8_t *pbuf, uint8_t len)
-{
-    uint8_t idx = 0;
-
-    for (idx = 0; idx < len; idx++) {
-        if (((value >> 28)) < 0xA) {
-            pbuf[2 * idx] = (value >> 28) + '0';
-        } else {
-            pbuf[2 * idx] = (value >> 28) + 'A' - 10;
-        }
-
-        value = value << 4;
-
-        pbuf[2 * idx + 1] = 0;
-    }
 }
 
 /*******************************************************************************

--- a/src/main/vcp/usb_conf.h
+++ b/src/main/vcp/usb_conf.h
@@ -97,6 +97,8 @@
 #define  EP6_OUT_Callback   NOP_Process
 #define  EP7_OUT_Callback   NOP_Process
 
+#define USB_MAX_STR_DESC_SIZ 50
+
 #endif /* __USB_CONF_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/vcp/usb_desc.c
+++ b/src/main/vcp/usb_desc.c
@@ -123,27 +123,4 @@ VIRTUAL_COM_PORT_DATA_SIZE, /* wMaxPacketSize: */
 0x00, 0x00 /* bInterval */
 };
 
-/* USB String Descriptors */
-const uint8_t Virtual_Com_Port_StringLangID[VIRTUAL_COM_PORT_SIZ_STRING_LANGID] = {
-VIRTUAL_COM_PORT_SIZ_STRING_LANGID,
-USB_STRING_DESCRIPTOR_TYPE, 0x09, 0x04 /* LangID = 0x0409: U.S. English */
-};
-
-const uint8_t Virtual_Com_Port_StringVendor[VIRTUAL_COM_PORT_SIZ_STRING_VENDOR] = {
-VIRTUAL_COM_PORT_SIZ_STRING_VENDOR, /* Size of Vendor string */
-USB_STRING_DESCRIPTOR_TYPE, /* bDescriptorType*/
-/* Manufacturer: "STMicroelectronics" */
-'S', 0, 'T', 0, 'M', 0, 'i', 0, 'c', 0, 'r', 0, 'o', 0, 'e', 0, 'l', 0, 'e', 0, 'c', 0, 't', 0, 'r', 0, 'o', 0, 'n', 0, 'i', 0, 'c', 0, 's', 0 };
-
-const uint8_t Virtual_Com_Port_StringProduct[VIRTUAL_COM_PORT_SIZ_STRING_PRODUCT] = {
-VIRTUAL_COM_PORT_SIZ_STRING_PRODUCT, /* bLength */
-USB_STRING_DESCRIPTOR_TYPE, /* bDescriptorType */
-/* Product name: "STM32 Virtual COM Port" */
-'S', 0, 'T', 0, 'M', 0, '3', 0, '2', 0, ' ', 0, 'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0, 'a', 0, 'l', 0, ' ', 0, 'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0, 'o', 0, 'r', 0, 't', 0, ' ', 0, ' ', 0 };
-
-uint8_t Virtual_Com_Port_StringSerial[VIRTUAL_COM_PORT_SIZ_STRING_SERIAL] = {
-VIRTUAL_COM_PORT_SIZ_STRING_SERIAL, /* bLength */
-USB_STRING_DESCRIPTOR_TYPE, /* bDescriptorType */
-'S', 0, 'T', 0, 'M', 0, '3', 0, '2', 0 };
-
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/vcp/usb_desc.h
+++ b/src/main/vcp/usb_desc.h
@@ -30,6 +30,8 @@
 #define __USB_DESC_H
 
 /* Includes ------------------------------------------------------------------*/
+#include "platform.h"
+
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/
@@ -45,10 +47,6 @@
 
 #define VIRTUAL_COM_PORT_SIZ_DEVICE_DESC        18
 #define VIRTUAL_COM_PORT_SIZ_CONFIG_DESC        67
-#define VIRTUAL_COM_PORT_SIZ_STRING_LANGID      4
-#define VIRTUAL_COM_PORT_SIZ_STRING_VENDOR      38
-#define VIRTUAL_COM_PORT_SIZ_STRING_PRODUCT     50
-#define VIRTUAL_COM_PORT_SIZ_STRING_SERIAL      26
 
 #define STANDARD_ENDPOINT_DESC_SIZE             0x09
 
@@ -56,10 +54,17 @@
 extern const uint8_t Virtual_Com_Port_DeviceDescriptor[VIRTUAL_COM_PORT_SIZ_DEVICE_DESC];
 extern const uint8_t Virtual_Com_Port_ConfigDescriptor[VIRTUAL_COM_PORT_SIZ_CONFIG_DESC];
 
-extern const uint8_t Virtual_Com_Port_StringLangID[VIRTUAL_COM_PORT_SIZ_STRING_LANGID];
-extern const uint8_t Virtual_Com_Port_StringVendor[VIRTUAL_COM_PORT_SIZ_STRING_VENDOR];
-extern const uint8_t Virtual_Com_Port_StringProduct[VIRTUAL_COM_PORT_SIZ_STRING_PRODUCT];
-extern uint8_t Virtual_Com_Port_StringSerial[VIRTUAL_COM_PORT_SIZ_STRING_SERIAL];
+
+#define USBD_MANUFACTURER_STRING        "RaceFlight"
+
+#ifndef USBD_PRODUCT_STRING
+  #define USBD_PRODUCT_STRING          "STM32 Virtual ComPort"
+#endif /* USBD_PRODUCT_STRING */
+
+#ifndef USBD_SERIALNUMBER_STRING
+  // start of STM32 flash
+  #define USBD_SERIALNUMBER_STRING     "0x8000000"
+#endif /* USBD_SERIALNUMBER_STRING */
 
 #endif /* __USB_DESC_H */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/vcp/usb_prop.c
+++ b/src/main/vcp/usb_prop.c
@@ -45,6 +45,9 @@ LINE_CODING linecoding = { 115200, /* baud rate*/
 0x08 /* no. of bits 8*/
 };
 
+static uint8_t UsbStringBuf[USB_MAX_STR_DESC_SIZ];
+static ONE_DESCRIPTOR UsbStringDesc;
+
 /* -------------------------------------------------------------------------- */
 /*  Structures initializations */
 /* -------------------------------------------------------------------------- */
@@ -71,9 +74,6 @@ VIRTUAL_COM_PORT_SIZ_DEVICE_DESC };
 ONE_DESCRIPTOR Config_Descriptor = { (uint8_t*)Virtual_Com_Port_ConfigDescriptor,
 VIRTUAL_COM_PORT_SIZ_CONFIG_DESC };
 
-ONE_DESCRIPTOR String_Descriptor[4] = { { (uint8_t*)Virtual_Com_Port_StringLangID, VIRTUAL_COM_PORT_SIZ_STRING_LANGID }, { (uint8_t*)Virtual_Com_Port_StringVendor, VIRTUAL_COM_PORT_SIZ_STRING_VENDOR }, { (uint8_t*)Virtual_Com_Port_StringProduct,
-        VIRTUAL_COM_PORT_SIZ_STRING_PRODUCT }, { (uint8_t*)Virtual_Com_Port_StringSerial, VIRTUAL_COM_PORT_SIZ_STRING_SERIAL } };
-
 /* Extern variables ----------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Extern function prototypes ------------------------------------------------*/
@@ -87,11 +87,6 @@ ONE_DESCRIPTOR String_Descriptor[4] = { { (uint8_t*)Virtual_Com_Port_StringLangI
  *******************************************************************************/
 void Virtual_Com_Port_init(void)
 {
-
-    /* Update the serial number string descriptor with the data from the unique
-     ID*/
-    Get_SerialNum();
-
     pInformation->Current_Configuration = 0;
 
     /* Connect the device */
@@ -290,6 +285,36 @@ uint8_t *Virtual_Com_Port_GetConfigDescriptor(uint16_t Length)
     return Standard_GetDescriptorData(Length, &Config_Descriptor);
 }
 
+static uint16_t Virtual_Com_Port_GetStringLength(const uint8_t *buf)
+{
+    uint8_t  len = 0;
+
+    while (*buf != 0) {
+        len++;
+        buf++;
+    }
+
+    return len;
+}
+
+static uint8_t *Virtual_Com_Port_GetString(const uint8_t *str, uint8_t *buf, uint16_t *len)
+{
+    uint8_t idx = 0;
+
+    if (str != NULL) {
+        *len =  Virtual_Com_Port_GetStringLength(str) * 2 + 2;
+        buf[idx++] = *len;
+        buf[idx++] =  USB_STRING_DESCRIPTOR_TYPE;
+
+        while (*str != 0) {
+            buf[idx++] = *str++;
+            buf[idx++] =  0x00;
+        }
+    } 
+
+    return buf;
+}
+
 /*******************************************************************************
  * Function Name  : Virtual_Com_Port_GetStringDescriptor
  * Description    : Gets the string descriptors according to the needed index
@@ -300,11 +325,32 @@ uint8_t *Virtual_Com_Port_GetConfigDescriptor(uint16_t Length)
 uint8_t *Virtual_Com_Port_GetStringDescriptor(uint16_t Length)
 {
     uint8_t wValue0 = pInformation->USBwValue0;
-    if (wValue0 > 4) {
+    uint16_t descLength = 0;
+
+    switch (wValue0) {
+    case 0:
+        UsbStringBuf[0] = 4;
+        UsbStringBuf[1] = USB_STRING_DESCRIPTOR_TYPE;
+        UsbStringBuf[2] = 0x09;
+        UsbStringBuf[3] = 0x04;
+        descLength = 4;
+        break;
+    case 1:
+        Virtual_Com_Port_GetString((uint8_t *)USBD_MANUFACTURER_STRING, UsbStringBuf, &descLength);
+        break;
+    case 2:
+        Virtual_Com_Port_GetString((uint8_t *)USBD_PRODUCT_STRING, UsbStringBuf, &descLength);
+        break;
+    case 3:
+        Virtual_Com_Port_GetString((uint8_t *)USBD_SERIALNUMBER_STRING, UsbStringBuf, &descLength);
+        break;
+    default:
         return NULL;
-    } else {
-        return Standard_GetDescriptorData(Length, &String_Descriptor[wValue0]);
     }
+
+    UsbStringDesc.Descriptor_Size = descLength;
+    UsbStringDesc.Descriptor = UsbStringBuf;
+    return Standard_GetDescriptorData(Length, &UsbStringDesc);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Continues from #75. Adds the functionality to F1 and F3 USB driver. Tested on Sparky 1.
