### PR TITLE
Setup WS2811 LED strip to allow target definitions

### DIFF
--- a/src/main/drivers/light_ws2811strip_stm32f4xx.c
+++ b/src/main/drivers/light_ws2811strip_stm32f4xx.c
@@ -24,9 +24,17 @@
 #include "light_ws2811strip.h"
 #include "dma.h"
 #include "nvic.h"
+#include "io.h"
 
-#ifndef WS2811_DMA_HANDLER_IDENTIFER
-#define WS2811_DMA_HANDLER_IDENTIFER DMA1_ST2_HANDLER
+#ifndef WS2811_PIN
+#define WS2811_GPIO_AF                  GPIO_AF_TIM5
+#define WS2811_PIN                      PA0 
+#define WS2811_TIMER                    TIM5
+#define WS2811_TIMER_APB1_PERIPHERAL    RCC_APB1Periph_TIM5
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST2_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream2
+#define WS2811_DMA_CHANNEL              DMA_Channel_6
+#define WS2811_DMA_IRQ                  DMA1_Stream2_IRQn
 #endif
 
 void ws2811DMAHandler(DMA_Stream_TypeDef *stream)
@@ -34,7 +42,7 @@ void ws2811DMAHandler(DMA_Stream_TypeDef *stream)
     if (DMA_GetFlagStatus(stream, DMA_FLAG_TCIF2)) {
         ws2811LedDataTransferInProgress = 0;
         DMA_Cmd(stream, DISABLE);
-        TIM_DMACmd(TIM5, TIM_DMA_CC1, DISABLE);
+        TIM_DMACmd(WS2811_TIMER, TIM_DMA_CC1, DISABLE);
         DMA_ClearITPendingBit(stream, DMA_IT_TCIF2);
     }
 }
@@ -43,28 +51,22 @@ void ws2811LedStripHardwareInit(void)
 {
     TIM_TimeBaseInitTypeDef  TIM_TimeBaseStructure;
     TIM_OCInitTypeDef  TIM_OCInitStructure;
-    GPIO_InitTypeDef GPIO_InitStructure;
     DMA_InitTypeDef DMA_InitStructure;
 
     uint16_t prescalerValue;
 
-    RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
-    RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM5, ENABLE);
-    RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_DMA1, ENABLE);
-
+#ifdef WS2811_TIMER_APB1_PERIPHERAL
+    RCC_APB1PeriphClockCmd(WS2811_TIMER_APB1_PERIPHERAL, ENABLE);
+#elif WS2811_TIMER_APB2_PERIPHERAL
+    RCC_APB2PeriphClockCmd(WS2811_TIMER_APB2_PERIPHERAL, ENABLE);
+#endif
 
     /* GPIOA Configuration: TIM5 Channel 1 as alternate function push-pull */
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0;
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-    GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
-    GPIO_Init(GPIOA, &GPIO_InitStructure);
-
-    GPIO_PinAFConfig(GPIOA, GPIO_PinSource0,  GPIO_AF_TIM5);
-
+    IOInit(IOGetByTag(IO_TAG(WS2811_PIN)), OWNER_SYSTEM, RESOURCE_OUTPUT);
+    IOConfigGPIOAF(IOGetByTag(IO_TAG(WS2811_PIN)), IOCFG_AF_PP, WS2811_GPIO_AF);
+    
     // Stop timer
-    TIM_Cmd(TIM5, DISABLE);
+    TIM_Cmd(WS2811_TIMER, DISABLE);
 
     /* Compute the prescaler value */
     prescalerValue = (uint16_t) (SystemCoreClock / 2 / 84000000) - 1;
@@ -73,27 +75,27 @@ void ws2811LedStripHardwareInit(void)
     TIM_TimeBaseStructure.TIM_Prescaler = prescalerValue;
     TIM_TimeBaseStructure.TIM_ClockDivision = 0;
     TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
-    TIM_TimeBaseInit(TIM5, &TIM_TimeBaseStructure);
+    TIM_TimeBaseInit(WS2811_TIMER, &TIM_TimeBaseStructure);
 
     /* PWM1 Mode configuration: Channel1 */
     TIM_OCInitStructure.TIM_OCMode = TIM_OCMode_PWM1;
     TIM_OCInitStructure.TIM_OutputState = TIM_OutputState_Enable;
     TIM_OCInitStructure.TIM_Pulse = 0;
     TIM_OCInitStructure.TIM_OCPolarity = TIM_OCPolarity_High;
-    TIM_OC1Init(TIM5, &TIM_OCInitStructure);
-    TIM_OC1PreloadConfig(TIM5, TIM_OCPreload_Enable);
+    TIM_OC1Init(WS2811_TIMER, &TIM_OCInitStructure);
+    TIM_OC1PreloadConfig(WS2811_TIMER, TIM_OCPreload_Enable);
 
-    TIM_Cmd(TIM5, ENABLE);
+    TIM_Cmd(WS2811_TIMER, ENABLE);
 
     dmaSetHandler(WS2811_DMA_HANDLER_IDENTIFER, ws2811DMAHandler);
 
     /* configure DMA */
     /* DMA1 Channel Config */
-    DMA_Cmd(DMA1_Stream2, DISABLE);            // disable DMA channel 6
-    DMA_DeInit(DMA1_Stream2);
+    DMA_Cmd(WS2811_DMA_STREAM, DISABLE);            // disable DMA1 stream 2
+    DMA_DeInit(WS2811_DMA_STREAM);
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_Channel = DMA_Channel_6;
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&(TIM5->CCR1);
+    DMA_InitStructure.DMA_Channel = WS2811_DMA_CHANNEL;
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&(WS2811_TIMER->CCR1);
     DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)ledStripDMABuffer;
     DMA_InitStructure.DMA_DIR = DMA_DIR_MemoryToPeripheral;
     DMA_InitStructure.DMA_BufferSize = WS2811_DMA_BUFFER_SIZE;
@@ -107,14 +109,14 @@ void ws2811LedStripHardwareInit(void)
     DMA_InitStructure.DMA_FIFOThreshold = DMA_FIFOThreshold_1QuarterFull;
     DMA_InitStructure.DMA_MemoryBurst = DMA_MemoryBurst_Single;
     DMA_InitStructure.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
-    DMA_Init(DMA1_Stream2, &DMA_InitStructure);
+    DMA_Init(WS2811_DMA_STREAM, &DMA_InitStructure);
 
-    DMA_ITConfig(DMA1_Stream2, DMA_IT_TC, ENABLE);
-    DMA_ClearITPendingBit(DMA1_Stream2, DMA_IT_TCIF2);               // clear DMA1 Channel 6 transfer complete flag
+    DMA_ITConfig(WS2811_DMA_STREAM, DMA_IT_TC, ENABLE);
+    DMA_ClearITPendingBit(WS2811_DMA_STREAM, DMA_IT_TCIF2);               // clear DMA1 Channel 6 transfer complete flag
 
     NVIC_InitTypeDef NVIC_InitStructure;
 
-    NVIC_InitStructure.NVIC_IRQChannel = DMA1_Stream2_IRQn;
+    NVIC_InitStructure.NVIC_IRQChannel = WS2811_DMA_IRQ;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_WS2811_DMA);
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_WS2811_DMA);
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
@@ -126,9 +128,9 @@ void ws2811LedStripHardwareInit(void)
 
 void ws2811LedStripDMAEnable(void)
 {
-    DMA_SetCurrDataCounter(DMA1_Stream2, WS2811_DMA_BUFFER_SIZE);  // load number of bytes to be transferred
-    TIM_SetCounter(TIM5, 0);
-    DMA_Cmd(DMA1_Stream2, ENABLE);
-    TIM_DMACmd(TIM5, TIM_DMA_CC1, ENABLE);
+    DMA_SetCurrDataCounter(WS2811_DMA_STREAM, WS2811_DMA_BUFFER_SIZE);  // load number of bytes to be transferred
+    TIM_SetCounter(WS2811_TIMER, 0);
+    DMA_Cmd(WS2811_DMA_STREAM, ENABLE);
+    TIM_DMACmd(WS2811_TIMER, TIM_DMA_CC1, ENABLE);
 }
 


### PR DESCRIPTION
This will allow putting in definition within the target files for setting up the WS2811 LED strips.

Top of the STM32F4xx file for WS2811 demonstrates the defines needed.

At some stage in the future dma and timers will need to be a hardware list like SPI and I2C and you just identify which you want to use, and configuring will be simplified.
