### PR TITLE
Updates to PWM code

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -35,6 +35,7 @@
 #include "drivers/serial.h"
 #include "drivers/compass.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/accgyro.h"
 #include "drivers/light_led.h"

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -35,6 +35,7 @@
 #include "drivers/serial.h"
 #include "drivers/compass.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/accgyro.h"
 #include "drivers/light_led.h"

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -36,6 +36,7 @@
 #include "drivers/system.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/serial.h"
 #include "drivers/gyro_sync.h"
@@ -688,7 +689,7 @@ static void resetConf(void)
 #ifdef ALIENFLIGHT
     featureSet(FEATURE_MOTOR_STOP);
     featureClear(FEATURE_ONESHOT125);
-
+    featureClear(FEATURE_USE_PWM_RATE);
 #ifdef ALIENFLIGHTF3
     masterConfig.batteryConfig.vbatscale = 20;
     masterConfig.mag_hardware = MAG_NONE;            // disabled by default
@@ -712,11 +713,11 @@ static void resetConf(void)
 #endif
     masterConfig.failsafeConfig.failsafe_delay = 2;
     masterConfig.failsafeConfig.failsafe_off_delay = 0;
-    masterConfig.mixerConfig.yaw_jump_prevention_limit = 500;
+    masterConfig.mixerConfig.yaw_jump_prevention_limit = YAW_JUMP_PREVENTION_LIMIT_HIGH;
     currentControlRateProfile->rcRate8 = 100;
     currentControlRateProfile->rates[FD_PITCH] = 20;
     currentControlRateProfile->rates[FD_ROLL] = 20;
-    currentControlRateProfile->rates[FD_YAW] = 20;
+    currentControlRateProfile->rates[FD_YAW] = 30;
     parseRcChannels("TAER1234", &masterConfig.rxConfig);
 
     //  { 1.0f, -0.414178f,  1.0f, -1.0f },          // REAR_R

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -25,15 +25,15 @@
 #include "gpio.h"
 #include "timer.h"
 
+#include "pwm_mapping.h"
 #include "pwm_output.h"
 #include "pwm_rx.h"
-#include "pwm_mapping.h"
 
-void pwmBrushedMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse);
+void pwmBrushedMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate);
 void pwmBrushlessMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse);
 void pwmOneshotMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint8_t useOneshot42);
-void pwmOneshotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse);
-void pwmMultiShotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse);
+void pwmOneshotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint8_t useOneshot42);
+void pwmMultiShotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate);
 void pwmMultiShotMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex);
 void pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse);
 
@@ -1159,7 +1159,6 @@ if (init->useBuzzerP6) {
 
         const timerHardware_t *timerHardwarePtr = &timerHardware[timerIndex];
 
-
 #ifdef OLIMEXINO_UNCUT_LED2_E_JUMPER
         // PWM2 is connected to LED2 on the board and cannot be connected unless you cut LED2_E
         if (timerIndex == PWM2)
@@ -1293,7 +1292,6 @@ if (init->useBuzzerP6) {
 #endif
         }
 
-
         if (init->useChannelForwarding && !init->airplane) {
 #if defined(NAZE) && defined(LED_STRIP_TIMER)
             // if LED strip is active, PWM5-8 are unavailable, so map AUX1+AUX2 to PWM13+PWM14
@@ -1329,43 +1327,43 @@ if (init->useBuzzerP6) {
         if (type == MAP_TO_PPM_INPUT) {
 #ifdef REVO
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM12);
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM8);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM12, init);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM8, init);
             }
 #endif
 #if defined(REVONANO) || defined(SPARKY) || defined(ALIENFLIGHTF3)
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM2);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM2, init);
             }
 #endif
 #ifdef SPARKY2
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM8);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM8, init);
             }
 #endif
 #ifdef ALIENFLIGHTF4
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM1);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM1, init);
             }
 #endif
 #ifdef AQ32_V2
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM4);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM4, init);
             }
 #endif
 #ifdef AQ32_V2
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM4);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM4, init);
             }
 #endif
 #ifdef VRCORE
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM1);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM1, init);
             }
 #endif
 #ifdef CC3D
             if (init->useMultiShot || init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
-                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM2);
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM2, init);
             }
 #endif
             ppmInConfig(timerHardwarePtr);
@@ -1382,10 +1380,9 @@ if (init->useBuzzerP6) {
             }
 #endif  
         
-            if (init->useOneshot) 
-            {
+            if (init->useOneshot) {
                 if (init->usePwmRate) {
-                    pwmOneshotPwmRateMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->idlePulse);
+                    pwmOneshotPwmRateMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->useOneshot42);
                 } else {
                     pwmOneshotMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->useOneshot42);
                 }
@@ -1393,13 +1390,13 @@ if (init->useBuzzerP6) {
             } 
             else if (init->useMultiShot) {
                 if (init->usePwmRate) {
-                    pwmMultiShotPwmRateMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->idlePulse);
+                    pwmMultiShotPwmRateMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate);
                 } else {
                 	pwmMultiShotMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount);
                 }
                 pwmOutputConfiguration.portConfigurations[pwmOutputConfiguration.outputCount].flags = PWM_PF_MOTOR | PWM_PF_OUTPUT_PROTOCOL_MULTISHOT|PWM_PF_OUTPUT_PROTOCOL_PWM ;
             } else if (isMotorBrushed(init->motorPwmRate)) {
-                pwmBrushedMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->idlePulse);
+                pwmBrushedMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate);
                 pwmOutputConfiguration.portConfigurations[pwmOutputConfiguration.outputCount].flags = PWM_PF_MOTOR | PWM_PF_MOTOR_MODE_BRUSHED | PWM_PF_OUTPUT_PROTOCOL_PWM;
             } else {
                 pwmBrushlessMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->idlePulse);

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -36,10 +36,10 @@
 #define MAX_INPUTS  8
 
 #define PWM_TIMER_MHZ 1
-//these three have to be the same because of the ppmAvoidPWMTimerClash functions
-#define ONESHOT_TIMER_MHZ 12
+#define ONESHOT125_TIMER_MHZ 4
+#define ONESHOT42_TIMER_MHZ 12
 #define MULTISHOT_TIMER_MHZ 12
-#define PWM_BRUSHED_TIMER_MHZ 12
+#define PWM_BRUSHED_TIMER_MHZ 24
 
 typedef struct sonarGPIOConfig_s {
     GPIO_TypeDef *gpio;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -125,7 +125,7 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timerHardware, uint8
 
 static void pwmWriteBrushed(uint8_t index, uint16_t value)
 {
-    *motors[index]->ccr = (uint16_t)((float)((value - 1000) * motors[index]->period / 1000)*1.5f); //Expecting 8MHz timer, multiply by 1.5 to scale to 12MHz timer
+    *motors[index]->ccr = (value - 1000) * motors[index]->period / 1000;
 }
 
 static void pwmWriteStandard(uint8_t index, uint16_t value)
@@ -133,27 +133,10 @@ static void pwmWriteStandard(uint8_t index, uint16_t value)
     *motors[index]->ccr = value;
 }
 
-#if defined(STM32F10X) && !defined(CC3D)
-static void pwmWriteOneshot125(uint8_t index, uint16_t value)
+static void pwmWriteOneshot(uint8_t index, uint16_t value)
 {
-    *motors[index]->ccr = value * 21 / 6;  // 24Mhz -> 8Mhz
+    *motors[index]->ccr = value / 2;
 }
-
-static void pwmWriteOneshot42(uint8_t index, uint16_t value)
-{
-    *motors[index]->ccr = value * 7 / 6;
-}
-#else
-static void pwmWriteOneshot125(uint8_t index, uint16_t value)
-{
-    *motors[index]->ccr = value * 3;
-}
-
-static void pwmWriteOneshot42(uint8_t index, uint16_t value)
-{
-    *motors[index]->ccr = value;
-}
-#endif
 
 static void pwmWriteMultiShot(uint8_t index, uint16_t value)
 {
@@ -170,7 +153,7 @@ void pwmShutdownPulsesForAllMotors(uint8_t motorCount)
 {
     uint8_t index;
 
-    for(index = 0; index < motorCount; index++){
+    for(index = 0; index < motorCount; index++) {
         // Set the compare register to 0, which stops the output pulsing if the timer overflows
         *motors[index]->ccr = 0;
     }
@@ -181,11 +164,9 @@ void pwmCompleteOneshotMotorUpdate(uint8_t motorCount)
     uint8_t index;
     TIM_TypeDef *lastTimerPtr = NULL;
 
-    for(index = 0; index < motorCount; index++)
-    {
+    for(index = 0; index < motorCount; index++) {
         // Force the timer to overflow if it's the first motor to output, or if we change timers
-        if(motors[index]->tim != lastTimerPtr)
-        {
+        if(motors[index]->tim != lastTimerPtr) {
             lastTimerPtr = motors[index]->tim;
             timerForceOverflow(motors[index]->tim);
         }
@@ -201,10 +182,10 @@ bool isMotorBrushed(uint16_t motorPwmRate)
     return (motorPwmRate > 500);
 }
 
-void pwmBrushedMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse)
+void pwmBrushedMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate)
 {
     uint32_t hz = PWM_BRUSHED_TIMER_MHZ * 1000000;
-    motors[motorIndex] = pwmOutConfig(timerHardware, PWM_BRUSHED_TIMER_MHZ, hz / motorPwmRate, idlePulse);
+    motors[motorIndex] = pwmOutConfig(timerHardware, PWM_BRUSHED_TIMER_MHZ, hz / motorPwmRate, 0);
     motors[motorIndex]->pwmWritePtr = pwmWriteBrushed;
 }
 
@@ -215,31 +196,31 @@ void pwmBrushlessMotorConfig(const timerHardware_t *timerHardware, uint8_t motor
     motors[motorIndex]->pwmWritePtr = pwmWriteStandard;
 }
 
-void pwmOneshotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse, uint8_t useOneshot42)
+void pwmOneshotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint8_t useOneshot42)
 {
-    uint32_t hz = ONESHOT_TIMER_MHZ * 1000000;
-    motors[motorIndex] = pwmOutConfig(timerHardware, ONESHOT_TIMER_MHZ, hz / motorPwmRate, idlePulse);
+    uint8_t mhz = ONESHOT125_TIMER_MHZ;
     if (useOneshot42) {
-        motors[motorIndex]->pwmWritePtr = pwmWriteOneshot42;
-    } else {
-        motors[motorIndex]->pwmWritePtr = pwmWriteOneshot125;
+        mhz = ONESHOT42_TIMER_MHZ;
     }
+    uint32_t hz = mhz * 1000000;
+    motors[motorIndex] = pwmOutConfig(timerHardware, mhz, hz / motorPwmRate, 0);
+    motors[motorIndex]->pwmWritePtr = pwmWriteOneshot;
 }
 
 void pwmOneshotMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint8_t useOneshot42)
 {
-    motors[motorIndex] = pwmOutConfig(timerHardware, ONESHOT_TIMER_MHZ, 0xFFFF, 0);
+    uint8_t mhz = ONESHOT125_TIMER_MHZ;
     if (useOneshot42) {
-        motors[motorIndex]->pwmWritePtr = pwmWriteOneshot42;
-    } else {
-        motors[motorIndex]->pwmWritePtr = pwmWriteOneshot125;
+        mhz = ONESHOT42_TIMER_MHZ;
     }
+    motors[motorIndex] = pwmOutConfig(timerHardware, mhz, 0xFFFF, 0);
+    motors[motorIndex]->pwmWritePtr = pwmWriteOneshot;
 }
 
-void pwmMultiShotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse)
+void pwmMultiShotPwmRateMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate)
 {
     uint32_t hz = MULTISHOT_TIMER_MHZ * 1000000;
-    motors[motorIndex] = pwmOutConfig(timerHardware, MULTISHOT_TIMER_MHZ, hz / motorPwmRate, idlePulse);
+    motors[motorIndex] = pwmOutConfig(timerHardware, MULTISHOT_TIMER_MHZ, hz / motorPwmRate, 0);
     motors[motorIndex]->pwmWritePtr = pwmWriteMultiShot;
 }
 

--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -32,7 +32,7 @@
 #include "timer.h"
 
 #include "pwm_mapping.h"
-
+#include "pwm_output.h"
 #include "pwm_rx.h"
 
 #define PPM_CAPTURE_COUNT 12
@@ -81,7 +81,7 @@ static uint16_t captures[PWM_PORTS_OR_PPM_CAPTURE_COUNT];
 
 static uint8_t ppmFrameCount = 0;
 static uint8_t lastPPMFrameCount = 0;
-static uint8_t ppmCountShift = 1;
+static uint8_t ppmCountDivisor = 1;
 
 typedef struct ppmDevice_s {
     uint8_t  pulseIndex;
@@ -158,9 +158,9 @@ static void ppmEdgeCallback(timerCCHandlerRec_t* cbRec, captureCompare_t capture
     /* Convert to 32-bit timer result */
     ppmDev.currentTime += ppmDev.largeCounter;
 
-    // Divide by 12 if Oneshot125 is active and this is a CC3D board
-    if (ppmCountShift > 1) {
-    	ppmDev.currentTime = ppmDev.currentTime / ppmCountShift;
+    // Divide value if Oneshot, Multishot or brushed motors are active and the timer is shared
+    if (ppmCountDivisor > 1) {
+    	ppmDev.currentTime = ppmDev.currentTime / ppmCountDivisor;
     }
 
     /* Capture computation */
@@ -326,10 +326,22 @@ void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel)
 #define UNUSED_PPM_TIMER_REFERENCE 0
 #define FIRST_PWM_PORT 0
 
-void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer)
+void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer, drv_pwm_config_t *init)
 {
     if (timerHardwarePtr->tim == sharedPwmTimer) {
-        ppmCountShift = 12;  // Divide by 12 if the timer is running at 12 MHz
+        if (init->useOneshot) {
+            if (init->useOneshot42) {
+                ppmCountDivisor = ONESHOT42_TIMER_MHZ;
+            } else {
+                ppmCountDivisor = ONESHOT125_TIMER_MHZ;
+            }
+        }
+        if (init->useMultiShot) {
+            ppmCountDivisor = MULTISHOT_TIMER_MHZ;
+        }
+        if (isMotorBrushed(init->motorPwmRate) && (!init->useOneshot || !init->useMultiShot)) {
+            ppmCountDivisor = PWM_BRUSHED_TIMER_MHZ;
+        }
     }
 }
 

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -26,7 +26,7 @@ typedef enum {
 
 
 void ppmInConfig(const timerHardware_t *timerHardwarePtr);
-void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer);
+void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer, drv_pwm_config_t *init);
 
 void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel);
 uint16_t pwmRead(uint8_t channel);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -45,6 +45,7 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/sdcard.h"
 #include "drivers/gyro_sync.h"

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -40,6 +40,7 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/sdcard.h"
 #include "drivers/gyro_sync.h"

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -350,17 +350,7 @@ void init(void)
     pwm_params.idlePulse = masterConfig.escAndServoConfig.mincommand;
     if (feature(FEATURE_3D)) {
         pwm_params.idlePulse = masterConfig.flight3DConfig.neutral3d;
-    } else {
-        if ((pwm_params.motorPwmRate > 500  && !masterConfig.force_motor_pwm_rate) && !feature(FEATURE_USE_PWM_RATE)) {
-            pwm_params.idlePulse = 0; // brushed motors
-        } else {
-        	if (feature(FEATURE_USE_PWM_RATE)) {
-        		pwm_params.idlePulse = (uint16_t)((float)(masterConfig.escAndServoConfig.mincommand-1000) / 4.1666f)+60;
-        	} else {
-        		pwm_params.idlePulse = (uint16_t)((float)masterConfig.escAndServoConfig.mincommand*1.5f);
-        	}
-        }
-    }    
+    }
 
     pwmOutputConfiguration_t *pwmOutputConfiguration = pwmInit(&pwm_params);
 

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -40,6 +40,7 @@
 #include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/gyro_sync.h"
 

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -27,6 +27,7 @@
 
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 
 #include "config/config.h"

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -39,6 +39,7 @@
 
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/system.h"
 #include "drivers/gyro_sync.h"

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -47,6 +47,7 @@
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/serial.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 
 #include "sensors/sensors.h"

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -23,6 +23,7 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/adc.h"
 #include "drivers/light_led.h"


### PR DESCRIPTION
Fix oneshot 125
General code cleanup

Please take a look at this. We still testing this here and our brushless build with KISS esc and oneshot is not really flying well. Al least oneshot is working again and motors running normally and smooth over the full range from motor tab. But in flight mode we have very heavy oscillations. Motors get hot quite fast. This brushless build is the best flying copter of this size with an firmware build from January. An brushed build in the same size if flying quite well with the same PID settings. I have seen this heavy oscillation's also with some other build during the last 3-4 weeks. 

Here are a two pictures.
brushless:
![f4bl_1](https://cloud.githubusercontent.com/assets/8107952/13864358/20cd5c18-eca1-11e5-9164-16072168b888.jpg)

brushed:
![quadf4_1](https://cloud.githubusercontent.com/assets/8107952/13864343/f9467ba2-eca0-11e5-8449-8dec1bf73cbb.jpg)

The idle pulse is not really needed during initialization in PWM_RATE mode. I also eliminate the many scaling during motor output and the timers running with the native speeds again. The PWM RX code is now taking care on scaling. The ppmAvoidPWMTimerClash() call is likely not really required for most of the F4 target sine at least 2/3 of them don't share timers between PWM and motors. Many of this calls can be eliminated in my view.

If there is someone out there with kiss and oneshot125 and can give this an try. This would be quite helpful. We don't get the Kiss to work with RC8 at all. Also if somebody can test the code with Multishot it would be helpful.
