### PR TITLE
Makefile: Hide LD command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1071,7 +1071,8 @@ $(TARGET_BIN): $(TARGET_ELF)
 	$(OBJCOPY) -O binary $< $@
 
 $(TARGET_ELF):  $(TARGET_OBJS)
-	$(CC) -o $@ $^ $(LDFLAGS)
+	@echo LD $(notdir $@)
+	@$(CC) -o $@ $^ $(LDFLAGS)
 	$(SIZE) $(TARGET_ELF) 
 
 # Compile


### PR DESCRIPTION
So it doesn't hide compile warnings/errors. The full command is really not helpful 99.99% of the time.

P.S. Your Makefile is very broken. It recompiles everything even when nothing changed. It needs a lot of love, or better, a full rewrite (no, I'm not volunteering :-P).
