### PR TITLE
fix beeper on SPARKY2

### DIFF
--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -36,7 +36,6 @@
 #define LED2 PB6
 
 #define BEEPER PC9
-#define BEEPER_INVERTED
 
 #define INVERTER PC6
 #define INVERTER_USART USART6


### PR DESCRIPTION
- this fixes annoying issue, where the beeper is on all the time
  (unless sound is played)
- it shouldn't be inverted as it uses LED PWM output
  
  from the doc at https://github.com/TauLabs/TauLabs/wiki/Sparky2
  
  ```
  Using buffered PWM outputs
  
  These outputs can handle more current and can be used for
  directly controlling external LEDs (see video here). These are
  mapped in software to PWM 7-10 and are available on the "LED"
  header on the back which is a 6 pin JST-SH header. They use an
  N-Channel FET so when the PWM pulse is high the FET is on and
  pulling the output towards ground.
  ```
