### PR TITLE
it seems like PC9 is the only pin w/ I2C3_SDA on the lqfp64 stm32f4

### DIFF
--- a/src/main/drivers/bus_i2c.c
+++ b/src/main/drivers/bus_i2c.c
@@ -72,7 +72,11 @@ static void i2cUnstick(IO_t scl, IO_t sda);
 #define I2C3_SCL PA8
 #endif
 #ifndef I2C3_SDA 
+#if defined(STM32F40_41xxx)
 #define I2C3_SDA PC9
+#else
+#define I2C3_SDA PB4
+#endif
 #endif
 #endif
 

--- a/src/main/drivers/bus_i2c.c
+++ b/src/main/drivers/bus_i2c.c
@@ -72,7 +72,7 @@ static void i2cUnstick(IO_t scl, IO_t sda);
 #define I2C3_SCL PA8
 #endif
 #ifndef I2C3_SDA 
-#define I2C3_SDA PB4 
+#define I2C3_SDA PC9
 #endif
 #endif
 


### PR DESCRIPTION
it looks like, from the [datasheet](http://www.st.com/web/en/resource/technical/document/datasheet/DM00037051.pdf), that `PB4`'s AFs are `NJTRST/ SPI3_MISO / TIM3_CH1 / SPI1_MISO / I2S3ext_SD/ EVENTOUT` (`I2S3ext_SD` != `I2C3_SDA` right?) and the only pin w/ `I2C3_SDA` is `PC9`

the only target that uses `I2CDEV_3` is the `REVONANO`. if anyone is using gps on this target, can they confirm it's broken or working?
